### PR TITLE
cmake: support gmime2 and add gmime link version test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,13 +60,13 @@ pkg_check_modules (GLIBMM2    REQUIRED  glibmm-2.4)
 pkg_check_modules (GMIME                gmime-3.0>=3.0.0)
 if (NOT GMIME_FOUND)
   # fall back to gmime 2
-  pkg_check_modules (GMIME                gmime-2.6>=2.6.0)
+  pkg_check_modules (GMIME              gmime-2.6>=2.6.0)
 endif()
 
 if (NOT GMIME_FOUND)
   message (
     FATAL_ERROR
-    "Gmime 3 or Gmime 2.6 required"
+    "GMime 3 or GMime 2.6 required"
     )
 endif()
 
@@ -150,6 +150,49 @@ add_definitions (
   -DBOOST_LOG_DYN_LINK
   -DDEBUG
   )
+
+## Check if notmuch is compiled against the same GMime library
+include(CheckCXXSourceRuns)
+set (CMAKE_REQUIRED_INCLUDES ${GMIME_INCLUDE_DIRS})
+set (CMAKE_REQUIRED_FLAGS    ${GMIME_CFLAGS})
+set (CMAKE_REQUIRED_FLAGS    ${GMIME_LDFLAGS})
+CHECK_CXX_SOURCE_RUNS(
+  "
+  # include <notmuch.h>
+  # include <gmime/gmime.h>
+
+  # include <iostream>
+
+  /* test if we are linked against the same GMime version as notmuch */
+
+  # if (GMIME_MAJOR_VERSION < 3)
+  # define g_mime_init() g_mime_init(0)
+  # define internet_address_list_parse(f,str) internet_address_list_parse_string(str)
+  # define internet_address_list_to_string(ia,f,encode) internet_address_list_to_string(ia,encode)
+  # endif
+
+  int main () {
+    g_mime_init ();
+
+    const char * a = \"Test <hey@asdf.da>\";
+    InternetAddressList * ia = internet_address_list_parse (NULL, a);
+
+    const char * addrs = internet_address_list_to_string (ia, NULL, false);
+
+    std::cout << \"address: \" << addrs << std::endl;
+
+    return 0;
+  }
+  "
+
+  GMIME_MATCHES)
+
+if (NOT GMIME_MATCHES)
+  message (
+    FATAL_ERROR
+    "You must compile and link against the same GMime version (e.g. 2.6 or 3) with both notmuch and astroid."
+    )
+endif()
 
 set ( GIT_DESC ${PROJECT_VERSION} )
 set ( PREFIX ${CMAKE_INSTALL_PREFIX} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,20 @@ message (STATUS "Building ${PROJECT_NAME} ${PROJECT_VERSION}")
 find_package ( PkgConfig REQUIRED )
 pkg_check_modules (GTKMM3     REQUIRED  gtkmm-3.0>=3.10)
 pkg_check_modules (GLIBMM2    REQUIRED  glibmm-2.4)
-pkg_check_modules (GMIME3     REQUIRED  gmime-3.0>=3.0.0)
+
+pkg_check_modules (GMIME                gmime-3.0>=3.0.0)
+if (NOT GMIME_FOUND)
+  # fall back to gmime 2
+  pkg_check_modules (GMIME                gmime-2.6>=2.6.0)
+endif()
+
+if (NOT GMIME_FOUND)
+  message (
+    FATAL_ERROR
+    "Gmime 3 or Gmime 2.6 required"
+    )
+endif()
+
 pkg_check_modules (WEBKITGTK3 REQUIRED  webkitgtk-3.0)
 pkg_check_modules (SASS       REQUIRED  libsass)
 
@@ -79,7 +92,7 @@ if(APPLE)
   # its own; hence we have to locate it manually
   set ( Gettext_LDFLAGS "-L/usr/local/opt/gettext/lib" )
 endif(APPLE)
-  
+
 find_library ( NOTMUCH_LIB notmuch )
 if(NOT NOTMUCH_LIB)
   message (FATAL_ERROR "notmuch library not found")
@@ -110,7 +123,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 include_directories (
   ${GTKMM3_INCLUDE_DIRS}
   ${GLIBMM2_INCLUDE_DIRS}
-  ${GMIME3_INCLUDE_DIRS}
+  ${GMIME_INCLUDE_DIRS}
   ${WEBKITGTK3_INCLUDE_DIRS}
   ${VTE2_INCLUDE_DIRS}
   ${SASS_INCLUDE_DIRS}
@@ -120,7 +133,7 @@ include_directories (
 add_compile_options (
   ${GTKMM3_CFLAGS}
   ${GLIBMM2_CFLAGS}
-  ${GMIME3_CFLAGS}
+  ${GMIME_CFLAGS}
   ${WEBKITGTK3_CFLAGS}
   ${VTE2_CFLAGS}
   ${SASS_CFLAGS}
@@ -158,7 +171,7 @@ else()
     FATAL_ERROR
     "libsass must be installed: could not find header file. You can disable libsass with --disable-libsass, however, that requires a SCSS compiler like 'sassc' which can be specified with --scss-compiler=<path to compiler>."
     )
-endif()  
+endif()
 
 include_directories (
   src/
@@ -175,7 +188,7 @@ include_directories (
 
 add_executable(
   astroid
-  
+
   src/account_manager.cc
   src/astroid.cc
   src/chunk.cc
@@ -241,7 +254,7 @@ target_link_libraries (
   ${WEBKITGTK3_LDFLAGS}
   ${GTKMM3_LDFLAGS}
   ${GLIBMM2_LDFLAGS}
-  ${GMIME3_LDFLAGS}
+  ${GMIME_LDFLAGS}
   ${VTE2_LDFLAGS}
   ${SASS_LDFLAGS}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
Fix #18 and #19. Please review if I am adding the GMIME flags twice now through the set CMAKE_REQUIRED_FLAGS stuff.. Necessary for the source test.