### PR TITLE
cmake: enable profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif ()
 #
 option (DISABLE_TERMINAL         "Disable embedded terminal (default = enabled)"  OFF)
 option (DISABLE_EMBEDDED_EDITOR  "Disable embedded editor (default = enabled)"    OFF)
+option (ENABLE_PROFILING         "Enable profiling (default = disabled)"          OFF)
 
 ##
 # welcome message
@@ -137,6 +138,12 @@ add_definitions (
   -DBOOST_LOG_DYN_LINK
   -DDEBUG
   )
+
+if (ENABLE_PROFILING)
+  message (STATUS "Enabling profiling.")
+  add_compile_options ( -pg )
+  set (CMAKE_EXE_LINKER_FLAGS "-pg")
+endif()
 
 set ( GIT_DESC ${PROJECT_VERSION} )
 set ( PREFIX ${CMAKE_INSTALL_PREFIX} )


### PR DESCRIPTION
Enable optional  profiling build