### PR TITLE
cmake: enable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,8 +270,8 @@ include_directories (
   ${CMAKE_BINARY_DIR}/src	# needed to find the generated build_config.hh
   )
 
-add_executable(
-  astroid
+add_library(
+  astr
 
   src/account_manager.cc
   src/astroid.cc
@@ -281,7 +281,6 @@ add_executable(
   src/config.cc
   src/crypto.cc
   src/db.cc
-  src/main.cc
   src/main_window.cc
   src/message_thread.cc
   src/poll.cc
@@ -333,7 +332,7 @@ add_executable(
   )
 
 target_link_libraries (
-  astroid
+  astr
   ${NOTMUCH_LIB}
   ${WEBKITGTK3_LDFLAGS}
   ${GTKMM3_LDFLAGS}
@@ -344,6 +343,17 @@ target_link_libraries (
   ${Boost_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
   ${Gettext_LDFLAGS}
+  )
+
+add_executable (
+  astroid
+
+  src/main.cc
+  )
+
+target_link_libraries (
+  astroid
+  astr
   )
 
 ##
@@ -362,7 +372,7 @@ else(DISABLE_EMBEDDED_EDITOR)
     add_definitions ( -DDISABLE_EMBEDDED )
   else(APPLE)
     target_sources (
-      astroid
+      astr
       PRIVATE
       src/modes/editor/editor.cc
       src/modes/editor/plugin.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,3 +466,8 @@ else()
     message (WARNING "Required packages not found; disabling plugins.")
   endif(INTROSPECTION_FOUND AND PEAS_FOUND)
 endif(DISABLE_PLUGINS)
+
+# Tests
+enable_testing()
+add_subdirectory (tests)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,20 +5,48 @@ find_package ( Boost REQUIRED
   unit_test_framework
   )
 
-add_executable ( 
-  test_generic
+function (add_astroid_test name target source)
 
-  test_generic.cc
-  )
+  add_executable (
+    ${target}
 
-target_link_libraries (
-  test_generic
+    ${source}
+    )
 
-  astr
-  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-  )
+  target_link_libraries (
+    ${target}
 
-add_test (NAME generic COMMAND test_generic)
+    astr
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    )
+
+  add_test (NAME ${name} COMMAND run_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${target})
+
+endfunction()
+
+configure_file (run_test.sh run_test.sh COPYONLY)
+
+
+# Add the tests
+
+add_astroid_test (generic   test_generic          test_generic.cc)
+add_astroid_test (compose   test_composed_message test_composed_message.cc)
+add_astroid_test (markdown  test_markdown         test_markdown.cc)
+add_astroid_test (non_existant test_non_existant_file test_non_existant_file.cc)
+add_astroid_test (open_db   test_open_db          test_open_db.cc)
+add_astroid_test (convert_error test_convert_error test_convert_error.cc)
+add_astroid_test (no_newline test_no_newline_msg  test_no_newline_msg.cc)
+add_astroid_test (mime_message test_mime_message  test_mime_message.cc)
+add_astroid_test (theme     test_theme            test_theme.cc)
+add_astroid_test (keybindings test_keybindings    test_keybindings.cc)
+add_astroid_test (bad_content_id test_bad_content_id test_bad_content_id.cc)
+add_astroid_test (notmuch   test_notmuch          test_notmuch.cc)
+add_astroid_test (notmuch_standalone test_notmuch_standalone test_notmuch_standalone.cc)
+add_astroid_test (address   test_address          test_address.cc)
+add_astroid_test (dates     test_dates            test_dates.cc)
+add_astroid_test (crypto    test_crypto           test_crypto.cc)
+add_astroid_test (gmime_version test_gmime_version test_gmime_version.cc)
+
 
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+##
+# Tests
+find_package ( Boost REQUIRED
+  COMPONENTS
+  unit_test_framework
+  )
+
+add_executable ( 
+  test_generic
+
+  test_generic.cc
+  )
+
+target_link_libraries (
+  test_generic
+
+  astr
+  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+  )
+
+add_test (NAME generic COMMAND test_generic)
+
+
+

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+#
+# Set up environment and run test specified on command line
+
+set -ep
+
+SRCDIR=${1}
+BINDIR=${2}
+TEST=${3}
+
+echo "Source dir: ${SRCDIR}"
+echo "Build dir:  ${BINDIR}"
+
+export NOTMUCH_CONFIG="${BINDIR}/tests/mail/test_config"
+export GNUPGHOME="${BINDIR}/tests/test_home/gnupg"
+
+gpgconf --kill all # stop all components
+
+if [ ! -e ${NOTMUCH_CONFIG} ]; then
+  echo "Setting up test suite.."
+
+  notmuch_db="${BINDIR}/tests/mail/test_mail"
+  echo "setting up notmuch test db..: ${notmuch_db}"
+  mkdir -p "${notmuch_db}"
+
+  cp "${SRCDIR}/tests/mail/test_config.template" "${NOTMUCH_CONFIG}"
+  notmuch config set database.path "${notmuch_db}"
+
+  cp    ${SRCDIR}/tests/mail/*.eml ${notmuch_db}/..
+  cp -r ${SRCDIR}/tests/mail/test_mail/* ${notmuch_db}/
+  notmuch new
+
+  cp "${SRCDIR}/tests/forktee"* "${BINDIR}/tests/"
+
+  cp -r "${SRCDIR}/tests/test_home" "${BINDIR}/tests/"
+
+  # setup GPG
+  mkdir -p ${GNUPGHOME}
+  chmod og-rwx ${GNUPGHOME}
+
+  pushd ${GNUPGHOME}
+  gpg --batch --gen-key ${SRCDIR}/tests/foo1.key
+  gpg --batch --gen-key ${SRCDIR}/tests/foo2.key
+  gpg --batch --always-trust --import one.pub
+  gpg --batch --always-trust --import two.pub
+  echo "always-trust" > gpg.conf
+  popd
+
+  # set up theme
+  mkdir -p ${BINDIR}/ui
+  cp ${SRCDIR}/ui/thread-view.* ${BINDIR}/ui/
+fi
+
+echo "Running: ${TEST}.."
+
+pushd ${BINDIR}
+./tests/${TEST}
+popd
+
+


### PR DESCRIPTION
Splits build into astroid library and executable to avoid having to rebuild.

#2 